### PR TITLE
fix for loop in function wario_update_spin_input

### DIFF
--- a/movesets/vanilla-chars.lua
+++ b/movesets/vanilla-chars.lua
@@ -1088,7 +1088,7 @@ function wario_update_spin_input(m)
             end
             e.spinDirection = newDirection
         else
-            for i = ANGLE_QUEUE_SIZE, 0, -1 do
+            for i = ANGLE_QUEUE_SIZE, 2, -1 do
                 e.angleDeltaQueue[i] = e.angleDeltaQueue[i-1]
                 angleOverFrames = angleOverFrames + e.angleDeltaQueue[i]
             end


### PR DESCRIPTION
In this commit https://github.com/coop-deluxe/extra-characters-plus/commit/9b451bf6cb20945c7d9f966314a92b00fcfb7f92  the  e.angleDeltaQueue table went from being indexed from (0-8) to (1-9). The line this pull request changes incorrectly expanded the range of the for loop leading to said loop trying to access  nil entries in the e.angleDeltaQueue this commit fixes that change.
before this pull request 
![20260127213028_1](https://github.com/user-attachments/assets/21da075b-08ed-45ae-8dc5-0dc8a55343de)
after this pull request
![20260127213211_1](https://github.com/user-attachments/assets/7cb0898d-e61b-45d7-a583-46932158a0d9)
