### PR TITLE
Rosalina's Galaxy Life Meter

### DIFF
--- a/y-custom-geo-functions.lua
+++ b/y-custom-geo-functions.lua
@@ -35,7 +35,7 @@ local sSonicSpinBallActs = {
     [ACT_SONIC_HOMING_ATTACK]    = true,
 }
 
-
+ 
 local sSonicInstashieldActs = {
     [ACT_SONIC_SPIN_JUMP]        = true,
     [ACT_SONIC_AIR_SPIN]         = true,


### PR DESCRIPTION
A quarter day's worth of work, may need further polish (especially in the graphical department) but here it is

Additionally,
- got rid of manual sequential fields in characters' meter tables
- further `_G` purging
- added missing `allocate_mario_action`  in a DK action